### PR TITLE
Improve evaluation

### DIFF
--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -2,12 +2,13 @@ import numpy as np
 import pandas as pd
 
 def nwrmsle(predictions, targets, weights):
-    if type(predictions) == list:
-        predictions = np.array([np.nan if x < 0 else x for x in predictions])
-    elif type(predictions) == pd.Series:
-        predictions[predictions < 0] = np.nan
+
+    predictions = np.array([x if x > 0 else 0 for x in list(predictions)])
+
     targetsf = targets.astype(float)
-    targetsf[targets < 0] = np.nan
+    targetsf = np.array([x if x > 0 else 0 for x in list(targetsf)])
+
+
     weights = 1 + 0.25 * weights
     log_square_errors = (np.log(predictions + 1) - np.log(targetsf + 1)) ** 2
     return(np.sqrt(np.sum(weights * log_square_errors) / np.sum(weights)))

--- a/test/evaluation_test.py
+++ b/test/evaluation_test.py
@@ -24,3 +24,22 @@ def test_calculates_nwrmsle_for_imperfect_match():
 
     # Assert by-hand calculation of nwrmsle is reasonably close to python calculation
     assert approx(calculated_nwrmsle, 0.69314718)
+
+
+def test_eliminate_negative_values():
+    estimate = np.array([1, 2, 3, -1])
+    actual = np.array([1, 2, 3, -1])
+    weights = np.array([1, 1, 1, 1])
+    calculated_nwrmsle = evaluation.nwrmsle(estimate, actual, weights)
+
+    assert calculated_nwrmsle == 0.0
+
+
+def test_ignore_nan_values():
+    estimate = np.array([1, 2, 3, np.nan])
+    actual = np.array([1, 2, 3, np.nan])
+    weights = np.array([1, 1, 1, 1])
+    calculated_nwrmsle = evaluation.nwrmsle(estimate, actual, weights)
+
+    assert calculated_nwrmsle == 0.0
+


### PR DESCRIPTION
A few changes to the model evaluation script are necessary. Previously, when it encountered unexpected negative values, it would assign them to `NaN` values. However, this was causing issue in computing the final result. To address this, we do the following:

- Add tests to explicitly check for correctness when negative and NaN values are encountered
- Remove the type checking. This is no longer necessary, because we ultimately just put everything in a `numpy.array` and all of the handled input types are iterable, so we'll save some LOC by using list comprehensions instead.
- Use a rectifier instead of throwing to NaN values. This is implemented explicitly for semantics, though one imagines performance can be further improved by using a builtin vectorize `relu` method (an effort for a future PR?)