### PR TITLE
Change dvc config to use Google Storage as the default remote

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,4 @@
-['remote "local"']
-url = /tmp/dvc/twde
 [core]
-remote = local
+remote = default
+['remote "default"']
+url = gs://continuous-intelligence


### PR DESCRIPTION
This removes the local remote dependency and uses the `continuous-intelligence` bucket set up on Google Cloud.